### PR TITLE
リントルールの変更

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,1 +1,5 @@
 include: package:flutter_lints/flutter.yaml
+
+linter:
+  rules:
+    - require_trailing_commas

--- a/test/placeholder_test.dart
+++ b/test/placeholder_test.dart
@@ -1,0 +1,7 @@
+// TODO; flutter testでエラーが出ないようにするためのダミーファイルなので、後で消す
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test("Test test", () => null);
+}


### PR DESCRIPTION
末尾のコンマを強制するリントルールを`analysis_options.yaml`に追加しました。
ワークフロー内で静的解析が入るので、このルールはこれ以降のPR全てに適用されます。

[追記]
テストが１つもないとCIに通らないので、ダミーテストを追加しました。マージ後消します。