### PR TITLE
デプロイのワークフローを修正

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,6 +22,10 @@ jobs:
 
       - name: Install dependencies
         run: flutter pub get
+        
+      - name: Build runner
+        working-directory: ${{ env.package_dir }}
+        run: flutter pub run build_runner build --delete-conflicting-outputs
 
       - name: Build web app
         run: flutter build web --release --base-href "/${{ github.event.repository.name }}/"


### PR DESCRIPTION
自動生成ファイルがgit管理されていないためビルドに失敗しています。
`build_runner`を実行するステップを追加してこの問題を解消するためのPRです。