### PR TITLE
インクリメンタルサーチの実装

### DIFF
--- a/lib/components/common/search_box.dart
+++ b/lib/components/common/search_box.dart
@@ -9,14 +9,19 @@ class SearchBox extends HookWidget {
     this.hintText,
     this.onSubmitted,
     this.onTextChanged,
+    this.onTap,
     this.autoFocus = true,
+    this.readOnly = false,
   });
 
   final String? initialText;
   final String? hintText;
   final void Function(String text)? onSubmitted;
   final void Function(String text)? onTextChanged;
+  final VoidCallback? onTap;
   final bool autoFocus;
+  final bool readOnly;
+
 
   @override
   Widget build(BuildContext context) {
@@ -69,7 +74,9 @@ class SearchBox extends HookWidget {
     final textFiled = TextField(
       onChanged: onTextChanged,
       onSubmitted: onSubmitted,
+      onTap: onTap,
       controller: controller,
+      readOnly: readOnly,
       autofocus: autoFocus,
       textInputAction: TextInputAction.search,
       focusNode: focusNode,

--- a/lib/components/common/search_box.dart
+++ b/lib/components/common/search_box.dart
@@ -22,7 +22,6 @@ class SearchBox extends HookWidget {
   final bool autoFocus;
   final bool readOnly;
 
-
   @override
   Widget build(BuildContext context) {
     final controller = useTextEditingController(text: initialText);
@@ -62,7 +61,8 @@ class SearchBox extends HookWidget {
       false => const Icon(OctIcons.search_24),
     };
 
-    final clearButton = switch (hasFocus && text.isNotEmpty) {
+    bool showClearButton = !readOnly && hasFocus && text.isNotEmpty;
+    final clearButton = switch (showClearButton) {
       true => IconButton(
           onPressed: onClearButtonPressed,
           icon: const Icon(OctIcons.x_16),

--- a/lib/components/common/search_box.dart
+++ b/lib/components/common/search_box.dart
@@ -8,11 +8,13 @@ class SearchBox extends HookWidget {
     this.initialText,
     this.onSubmitted,
     this.onTextChanged,
+    this.autoFocus = true,
   });
 
   final String? initialText;
   final void Function(String text)? onSubmitted;
   final void Function(String text)? onTextChanged;
+  final bool autoFocus;
 
   @override
   Widget build(BuildContext context) {
@@ -53,6 +55,14 @@ class SearchBox extends HookWidget {
       false => null,
     };
 
+    final textFiled = TextField(
+      onChanged: onTextChanged,
+      onSubmitted: onSubmitted,
+      controller: controller,
+      autofocus: autoFocus,
+      textInputAction: TextInputAction.search,
+    );
+
     return Container(
       clipBehavior: Clip.antiAlias,
       decoration: const ShapeDecoration(
@@ -67,11 +77,7 @@ class SearchBox extends HookWidget {
             Expanded(
               child: Focus(
                 onFocusChange: onFocusChanged,
-                child: TextField(
-                  onChanged: onTextChanged,
-                  onSubmitted: onSubmitted,
-                  controller: controller,
-                ),
+                child: textFiled,
               ),
             ),
             if (clearButton != null) clearButton,

--- a/lib/components/common/search_box.dart
+++ b/lib/components/common/search_box.dart
@@ -7,10 +7,12 @@ class SearchBox extends HookWidget {
     super.key,
     this.initialText,
     this.onSubmitted,
+    this.onTextChanged,
   });
 
   final String? initialText;
   final void Function(String text)? onSubmitted;
+  final void Function(String text)? onTextChanged;
 
   @override
   Widget build(BuildContext context) {
@@ -29,6 +31,7 @@ class SearchBox extends HookWidget {
 
     void onTextChanged(String text) {
       hasText.value = text.isNotEmpty;
+      this.onTextChanged?.call(text);
     }
 
     void onBackButtonPressed() => Navigator.of(context).pop();

--- a/lib/components/common/search_box.dart
+++ b/lib/components/common/search_box.dart
@@ -27,6 +27,7 @@ class SearchBox extends HookWidget {
 
     void onClearButtonPressed() {
       controller.text = "";
+      this.onTextChanged?.call("");
     }
 
     void onTextChanged(String text) {

--- a/lib/components/common/search_box.dart
+++ b/lib/components/common/search_box.dart
@@ -51,6 +51,7 @@ class SearchBox extends HookWidget {
       true => IconButton(
           onPressed: onBackButtonPressed,
           icon: const Icon(Icons.arrow_back),
+          tooltip: "Back",
         ),
       false => const Icon(OctIcons.search_24),
     };
@@ -59,6 +60,7 @@ class SearchBox extends HookWidget {
       true => IconButton(
           onPressed: onClearButtonPressed,
           icon: const Icon(OctIcons.x_16),
+          tooltip: "Clear field",
         ),
       false => null,
     };

--- a/lib/components/common/search_box.dart
+++ b/lib/components/common/search_box.dart
@@ -19,6 +19,7 @@ class SearchBox extends HookWidget {
   @override
   Widget build(BuildContext context) {
     final controller = useTextEditingController(text: initialText);
+    final focusNode = useFocusNode();
     final hasFocus = useState(false);
     final hasText = useState(initialText?.isNotEmpty == true);
 
@@ -34,6 +35,15 @@ class SearchBox extends HookWidget {
     void onTextChanged(String text) {
       hasText.value = text.isNotEmpty;
       this.onTextChanged?.call(text);
+    }
+
+    void onSubmitted(String text) {
+      if (text.isNotEmpty) {
+        this.onSubmitted?.call(text);
+      } else {
+        // 何も入力されていない場合はキーボードを閉じない
+        focusNode.requestFocus();
+      }
     }
 
     void onBackButtonPressed() => Navigator.of(context).pop();
@@ -61,6 +71,7 @@ class SearchBox extends HookWidget {
       controller: controller,
       autofocus: autoFocus,
       textInputAction: TextInputAction.search,
+      focusNode: focusNode,
     );
 
     return Container(

--- a/lib/fakes/services/github/search/fake_search_repositories.dart
+++ b/lib/fakes/services/github/search/fake_search_repositories.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:yumemi_flutter_codecheck/fakes/services/github/faker.dart';
 import 'package:yumemi_flutter_codecheck/services/github/search/search_repositories.dart';
@@ -7,7 +9,7 @@ final fakeRepositoriesProvider = FutureProvider.autoDispose.family(
   (ref, RepositoriesProviderParams params) async {
     final totalCount = faker.randomGenerator.integer(100);
     final items = List.generate(
-      totalCount,
+      min(totalCount, params.perPage),
       (_) {
         return RepositoryOverview(
           name: faker.lorem.word(),

--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -11,8 +11,8 @@ class Home extends StatelessWidget {
   Widget build(BuildContext context) {
     void onTapSearchBar() async {
       final query = await IncrementalSearch.showAsDialog(
-        context,
-        const SearchQuery(keywords: ""),
+        context: context,
+        initialQuery: const SearchQuery(keywords: ""),
       );
       if (query != null && context.mounted) {
         context.push("/search", extra: query);

--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:yumemi_flutter_codecheck/components/common/search_box.dart';
 import 'package:yumemi_flutter_codecheck/screens/incremental_search.dart';
 import 'package:yumemi_flutter_codecheck/services/github/search/types/search_query.dart';
 
@@ -10,24 +11,17 @@ class Home extends StatelessWidget {
     return Scaffold(
       backgroundColor: Theme.of(context).colorScheme.surface,
       body: Center(
-        child: TextButton(
-          onPressed: () {
+        child: SearchBox(
+          autoFocus: false,
+          readOnly: true,
+          onTap: () {
             IncrementalSearch.showAsDialog(
               context,
               const SearchQuery(keywords: ""),
             );
           },
-          child: const Text("search"),
+          hintText: "Search repositories",
         ),
-        // child: SearchBox(
-        //   onSubmitted: (text) {
-        //     final trimmed = text.trim();
-        //     if (trimmed.isNotEmpty) {
-        //       final query = SearchQuery(keywords: trimmed);
-        //       context.push("/search", extra: query);
-        //     }
-        //   },
-        // ),
       ),
     );
   }

--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 import 'package:yumemi_flutter_codecheck/components/common/search_box.dart';
 import 'package:yumemi_flutter_codecheck/screens/incremental_search.dart';
 import 'package:yumemi_flutter_codecheck/services/github/search/types/search_query.dart';
@@ -8,18 +9,23 @@ class Home extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    void onTapSearchBar() async {
+      final query = await IncrementalSearch.showAsDialog(
+        context,
+        const SearchQuery(keywords: ""),
+      );
+      if (query != null && context.mounted) {
+        context.push("/search", extra: query);
+      }
+    }
+
     return Scaffold(
       backgroundColor: Theme.of(context).colorScheme.surface,
       body: Center(
         child: SearchBox(
           autoFocus: false,
           readOnly: true,
-          onTap: () {
-            IncrementalSearch.showAsDialog(
-              context,
-              const SearchQuery(keywords: ""),
-            );
-          },
+          onTap: onTapSearchBar,
           hintText: "Search repositories",
         ),
       ),

--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:yumemi_flutter_codecheck/screens/incremental_search.dart';
+import 'package:yumemi_flutter_codecheck/services/github/search/types/search_query.dart';
 
 class Home extends StatelessWidget {
   const Home({super.key});
@@ -10,10 +11,14 @@ class Home extends StatelessWidget {
       backgroundColor: Theme.of(context).colorScheme.surface,
       body: Center(
         child: TextButton(
-            onPressed: () {
-              IncrementalSearch.show(context);
-            },
-            child: Text("search")),
+          onPressed: () {
+            IncrementalSearch.showAsDialog(
+              context,
+              const SearchQuery(keywords: ""),
+            );
+          },
+          child: const Text("search"),
+        ),
         // child: SearchBox(
         //   onSubmitted: (text) {
         //     final trimmed = text.trim();

--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -1,7 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:go_router/go_router.dart';
-import 'package:yumemi_flutter_codecheck/components/common/search_box.dart';
-import 'package:yumemi_flutter_codecheck/services/github/search/types/search_query.dart';
+import 'package:yumemi_flutter_codecheck/screens/incremental_search.dart';
 
 class Home extends StatelessWidget {
   const Home({super.key});
@@ -11,15 +9,20 @@ class Home extends StatelessWidget {
     return Scaffold(
       backgroundColor: Theme.of(context).colorScheme.surface,
       body: Center(
-        child: SearchBox(
-          onSubmitted: (text) {
-            final trimmed = text.trim();
-            if (trimmed.isNotEmpty) {
-              final query = SearchQuery(keywords: trimmed);
-              context.push("/search", extra: query);
-            }
-          },
-        ),
+        child: TextButton(
+            onPressed: () {
+              IncrementalSearch.show(context);
+            },
+            child: Text("search")),
+        // child: SearchBox(
+        //   onSubmitted: (text) {
+        //     final trimmed = text.trim();
+        //     if (trimmed.isNotEmpty) {
+        //       final query = SearchQuery(keywords: trimmed);
+        //       context.push("/search", extra: query);
+        //     }
+        //   },
+        // ),
       ),
     );
   }

--- a/lib/screens/incremental_search.dart
+++ b/lib/screens/incremental_search.dart
@@ -43,6 +43,7 @@ class IncrementalSearch extends HookWidget {
           initialText: query.value.keywords,
           onSubmitted: onKeywordsSubmitted,
           onTextChanged: onKeywordsChanged,
+          autoFocus: true,
         ),
       ),
       body: ValueListenableBuilder(

--- a/lib/screens/incremental_search.dart
+++ b/lib/screens/incremental_search.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:go_router/go_router.dart';
+import 'package:yumemi_flutter_codecheck/common/errors/unkown_error_widget.dart';
+import 'package:yumemi_flutter_codecheck/components/common/search_box.dart';
+import 'package:yumemi_flutter_codecheck/components/github/repository_overview_list.dart';
+import 'package:yumemi_flutter_codecheck/services/github/search/types/repository_overview.dart';
+import 'package:yumemi_flutter_codecheck/services/github/search/types/search_query.dart';
+
+class IncrementalSearch extends HookWidget {
+  const IncrementalSearch({
+    super.key,
+    required this.query,
+  });
+
+  final SearchQuery query;
+
+  @override
+  Widget build(BuildContext context) {
+    final query = useState(this.query);
+
+    void onKeywordsSubmitted(String keywords) {
+      query.value = SearchQuery(
+        keywords: keywords.trim(),
+      );
+    }
+
+    void onKeywordsChanged(String keywords) {
+      query.value = SearchQuery(keywords: keywords.trim());
+    }
+
+    void onTapItem(RepositoryOverview repo) {
+      context.push("/repository/${repo.owner}/${repo.name}");
+    }
+
+    return Scaffold(
+      backgroundColor: Theme.of(context).colorScheme.surfaceVariant,
+      appBar: AppBar(
+        automaticallyImplyLeading: false,
+        title: SearchBox(
+          initialText: query.value.keywords,
+          onSubmitted: onKeywordsSubmitted,
+          onTextChanged: onKeywordsChanged,
+        ),
+      ),
+      body: RepositoryOverviewList(
+        query: query.value,
+        onTapItem: onTapItem,
+        loadingBuilder: (context) =>
+            const Center(child: CircularProgressIndicator()),
+        errorBuilder: (context, error, stackTrace) {
+          return UnkownErrorWidget(error, stackTrace);
+        },
+      ),
+    );
+  }
+
+  static void show(BuildContext context) {
+    Navigator.of(context).push(
+      MaterialPageRoute(
+        fullscreenDialog: true,
+        builder: (context) {
+          return const IncrementalSearch(query: SearchQuery(keywords: ""));
+        },
+      ),
+    );
+  }
+}

--- a/lib/screens/incremental_search.dart
+++ b/lib/screens/incremental_search.dart
@@ -35,16 +35,19 @@ class IncrementalSearch extends HookWidget {
       }
     }
 
+    final searchBar = SearchBox(
+      initialText: query.value.keywords,
+      hintText: "Search repositories",
+      onSubmitted: onKeywordsSubmitted,
+      onTextChanged: onKeywordsChanged,
+      autoFocus: true,
+    );
+
     return Scaffold(
       backgroundColor: Theme.of(context).colorScheme.surfaceVariant,
       appBar: AppBar(
         automaticallyImplyLeading: false,
-        title: SearchBox(
-          initialText: query.value.keywords,
-          onSubmitted: onKeywordsSubmitted,
-          onTextChanged: onKeywordsChanged,
-          autoFocus: true,
-        ),
+        title: searchBar,
       ),
       body: ValueListenableBuilder(
         valueListenable: query,

--- a/lib/screens/incremental_search.dart
+++ b/lib/screens/incremental_search.dart
@@ -55,14 +55,16 @@ class IncrementalSearch extends HookWidget {
     );
   }
 
-  static Future<SearchQuery?> showAsDialog(
-      BuildContext context, SearchQuery query) {
+  static Future<SearchQuery?> showAsDialog({
+    required BuildContext context,
+    required SearchQuery initialQuery,
+  }) {
     return Navigator.of(context).push(
       MaterialPageRoute(
         fullscreenDialog: true,
         builder: (context) {
           return IncrementalSearch(
-            initialQuery: query,
+            initialQuery: initialQuery,
           );
         },
       ),

--- a/lib/screens/incremental_search.dart
+++ b/lib/screens/incremental_search.dart
@@ -1,36 +1,38 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:flutter_octicons/flutter_octicons.dart';
 import 'package:go_router/go_router.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:yumemi_flutter_codecheck/common/errors/types/request_aborted_exception.dart';
 import 'package:yumemi_flutter_codecheck/common/errors/unkown_error_widget.dart';
 import 'package:yumemi_flutter_codecheck/components/common/search_box.dart';
-import 'package:yumemi_flutter_codecheck/components/github/repository_overview_list.dart';
+import 'package:yumemi_flutter_codecheck/services/github/search/search_repositories.dart';
 import 'package:yumemi_flutter_codecheck/services/github/search/types/repository_overview.dart';
 import 'package:yumemi_flutter_codecheck/services/github/search/types/search_query.dart';
 
 class IncrementalSearch extends HookWidget {
   const IncrementalSearch({
     super.key,
-    required this.query,
+    required this.initialQuery,
   });
 
-  final SearchQuery query;
+  final SearchQuery initialQuery;
 
   @override
   Widget build(BuildContext context) {
-    final query = useState(this.query);
-
-    void onKeywordsSubmitted(String keywords) {
-      query.value = SearchQuery(
-        keywords: keywords.trim(),
-      );
-    }
+    final query = useValueNotifier(initialQuery);
 
     void onKeywordsChanged(String keywords) {
       query.value = SearchQuery(keywords: keywords.trim());
     }
 
-    void onTapItem(RepositoryOverview repo) {
-      context.push("/repository/${repo.owner}/${repo.name}");
+    void onKeywordsSubmitted(String _) {
+      if (query.value.keywords.isNotEmpty) {
+        context
+            .push("/search", extra: query.value)
+            // 検索画面と一緒にこの画面もpopする
+            .then((_) => Navigator.of(context).pop());
+      }
     }
 
     return Scaffold(
@@ -43,26 +45,100 @@ class IncrementalSearch extends HookWidget {
           onTextChanged: onKeywordsChanged,
         ),
       ),
-      body: RepositoryOverviewList(
-        query: query.value,
-        onTapItem: onTapItem,
-        loadingBuilder: (context) =>
-            const Center(child: CircularProgressIndicator()),
-        errorBuilder: (context, error, stackTrace) {
-          return UnkownErrorWidget(error, stackTrace);
+      body: ValueListenableBuilder(
+        valueListenable: query,
+        builder: (context, query, _) {
+          return _SearchResultList(query);
         },
       ),
     );
   }
 
-  static void show(BuildContext context) {
+  static void showAsDialog(BuildContext context, SearchQuery query) {
     Navigator.of(context).push(
       MaterialPageRoute(
         fullscreenDialog: true,
         builder: (context) {
-          return const IncrementalSearch(query: SearchQuery(keywords: ""));
+          return IncrementalSearch(
+            initialQuery: query,
+          );
         },
       ),
+    );
+  }
+}
+
+final _incrementalSearchResult = FutureProvider.autoDispose.family(
+  (ref, SearchQuery query) async {
+    // 最初の`maxItemCount`件だけ取得する
+    const maxItemCount = 6;
+    const debounceDuration = Duration(milliseconds: 500);
+
+    if (query.keywords.isEmpty) {
+      return const <RepositoryOverview>[];
+    }
+
+    bool isCanceled = false;
+    ref.onDispose(() => isCanceled = true);
+    await Future.delayed(debounceDuration);
+    if (isCanceled) {
+      throw const RequestAbortedException("_incrementalSearchResult");
+    }
+
+    final params = (page: 1, perPage: maxItemCount, query: query);
+    final (_, items) = await ref.watch(repositoriesProvider(params).future);
+    return items;
+  },
+);
+
+class _SearchResultList extends ConsumerWidget {
+  const _SearchResultList(this.query);
+
+  final SearchQuery query;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return ref.watch(_incrementalSearchResult(query)).when(
+          data: _build,
+          error: UnkownErrorWidget.new,
+          loading: _buildLoading,
+        );
+  }
+
+  Widget _build(List<RepositoryOverview> items) {
+    return ListView.builder(
+      itemCount: items.length,
+      itemBuilder: (context, index) {
+        return _SearchResultItem(items[index]);
+      },
+    );
+  }
+
+  Widget _buildLoading() {
+    return const Center(child: CircularProgressIndicator());
+  }
+}
+
+class _SearchResultItem extends StatelessWidget {
+  const _SearchResultItem(this.repo);
+
+  final RepositoryOverview repo;
+
+  @override
+  Widget build(BuildContext context) {
+    void onTapItem() {
+      context.push("/repository/${repo.owner}/${repo.name}");
+    }
+
+    return ListTile(
+      onTap: onTapItem,
+      leading: const Icon(OctIcons.repo_24),
+      title: Text(
+        "${repo.owner}/${repo.name}",
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+      ),
+      trailing: const Icon(OctIcons.arrow_up_right_16),
     );
   }
 }

--- a/lib/screens/incremental_search.dart
+++ b/lib/screens/incremental_search.dart
@@ -28,10 +28,7 @@ class IncrementalSearch extends HookWidget {
 
     void onKeywordsSubmitted(String _) {
       if (query.value.keywords.isNotEmpty) {
-        context
-            .push("/search", extra: query.value)
-            // 検索画面と一緒にこの画面もpopする
-            .then((_) => Navigator.of(context).pop());
+        context.pop(query.value);
       }
     }
 
@@ -58,8 +55,9 @@ class IncrementalSearch extends HookWidget {
     );
   }
 
-  static void showAsDialog(BuildContext context, SearchQuery query) {
-    Navigator.of(context).push(
+  static Future<SearchQuery?> showAsDialog(
+      BuildContext context, SearchQuery query) {
+    return Navigator.of(context).push(
       MaterialPageRoute(
         fullscreenDialog: true,
         builder: (context) {

--- a/lib/screens/search.dart
+++ b/lib/screens/search.dart
@@ -23,7 +23,10 @@ class Search extends HookWidget {
     }
 
     void onTapSearchBar() async {
-      final newQuery = await IncrementalSearch.showAsDialog(context, query);
+      final newQuery = await IncrementalSearch.showAsDialog(
+        context: context,
+        initialQuery: query,
+      );
       if (newQuery != null && context.mounted) {
         context.push("/search", extra: newQuery);
       }

--- a/lib/screens/search.dart
+++ b/lib/screens/search.dart
@@ -35,6 +35,7 @@ class Search extends HookWidget {
         title: SearchBox(
           initialText: query.value.keywords,
           onSubmitted: onNewKeywordsSubmitted,
+          autoFocus: false,
         ),
       ),
       body: RepositoryOverviewList(

--- a/lib/screens/search.dart
+++ b/lib/screens/search.dart
@@ -22,8 +22,11 @@ class Search extends HookWidget {
       context.push("/repository/${repo.owner}/${repo.name}");
     }
 
-    void onTapSearchBar() {
-      IncrementalSearch.showAsDialog(context, query);
+    void onTapSearchBar() async {
+      final newQuery = await IncrementalSearch.showAsDialog(context, query);
+      if (newQuery != null && context.mounted) {
+        context.push("/search", extra: newQuery);
+      }
     }
 
     final searchBar = AppBar(

--- a/lib/screens/search.dart
+++ b/lib/screens/search.dart
@@ -4,6 +4,7 @@ import 'package:go_router/go_router.dart';
 import 'package:yumemi_flutter_codecheck/common/errors/unkown_error_widget.dart';
 import 'package:yumemi_flutter_codecheck/components/common/search_box.dart';
 import 'package:yumemi_flutter_codecheck/components/github/repository_overview_list.dart';
+import 'package:yumemi_flutter_codecheck/screens/incremental_search.dart';
 import 'package:yumemi_flutter_codecheck/services/github/search/types/repository_overview.dart';
 import 'package:yumemi_flutter_codecheck/services/github/search/types/search_query.dart';
 
@@ -17,29 +18,28 @@ class Search extends HookWidget {
 
   @override
   Widget build(BuildContext context) {
-    final query = useState(this.query);
-
-    void onNewKeywordsSubmitted(String keywords) {
-      query.value = SearchQuery(
-        keywords: keywords.trim(),
-      );
-    }
-
     void onTapItem(RepositoryOverview repo) {
       context.push("/repository/${repo.owner}/${repo.name}");
     }
 
-    return Scaffold(
-      appBar: AppBar(
-        automaticallyImplyLeading: false,
-        title: SearchBox(
-          initialText: query.value.keywords,
-          onSubmitted: onNewKeywordsSubmitted,
-          autoFocus: false,
-        ),
+    void onTapSearchBar() {
+      IncrementalSearch.showAsDialog(context, query);
+    }
+
+    final searchBar = AppBar(
+      automaticallyImplyLeading: false,
+      title: SearchBox(
+        initialText: query.keywords,
+        autoFocus: false,
+        readOnly: true,
+        onTap: onTapSearchBar,
       ),
+    );
+
+    return Scaffold(
+      appBar: searchBar,
       body: RepositoryOverviewList(
-        query: query.value,
+        query: query,
         onTapItem: onTapItem,
         loadingBuilder: (context) =>
             const Center(child: CircularProgressIndicator()),


### PR DESCRIPTION
インクリメンタルサーチを実装しました。

今までの挙動：
1. 検索バーをタップ（ホーム画面）
2. キーワードを入力
3. エンター（ホーム➡️検索画面へ遷移）
4. 検索結果を表示（検索画面）
5. 検索バーがタップされた場合：
	1. キーワードを入力 
	2. 新しい検索結果を表示（同じ検索画面）

新しい挙動：
1. 検索バーをタップ（ホーム画面➡️インクリメンタルサーチ画面）
2. キーワードを入力（インクリメンタルサーチ画面）
	- 入力が変化するたびに検索結果の上位N件を表示
	- リストのアイテムがタップされたらそのリポジトリの詳細画面へ遷移
3. エンター（ インクリメンタルサーチ画面を閉じる）
4. 検索結果を表示（検索画面）
5. 検索バーがタップされた場合：
	1. インクリメンタルサーチ画面へ遷移
