### PR TITLE
検索画面へのディープリンクを実装

### DIFF
--- a/lib/router.dart
+++ b/lib/router.dart
@@ -17,11 +17,13 @@ final router = GoRouter(
     ),
     GoRoute(
       path: "/search",
+      name: "search",
       builder: (context, state) {
-        return switch (state.extra) {
-          SearchQuery query => Search(query: query),
-          // TODO; ディープリンクに対応させる
-          _ => throw ArgumentError("'/search'はディープリンクに未対応"),
+        return switch (state.queryParameters) {
+          {"q": String keywords} => Search(
+              query: SearchQuery(keywords: keywords),
+            ),
+          _ => const NotFound(),
         };
       },
     ),

--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -16,7 +16,12 @@ class Home extends StatelessWidget {
         initialQuery: const SearchQuery(keywords: ""),
       );
       if (query != null && context.mounted) {
-        context.push("/search", extra: query);
+        context.pushNamed(
+          "search",
+          queryParameters: {
+            "q": query.keywords,
+          },
+        );
       }
     }
 

--- a/lib/screens/repository_details.dart
+++ b/lib/screens/repository_details.dart
@@ -50,7 +50,12 @@ class RepositoryDetails extends ConsumerWidget {
     void onTapHeader() {
       // ユーザーのリポジトリ一覧へ飛ぶ
       final query = SearchQuery(keywords: "user:${repository.owner}");
-      context.push("/search", extra: query);
+      context.pushNamed(
+        "search",
+        queryParameters: {
+          "q": query.keywords,
+        },
+      );
     }
 
     final textTheme = Theme.of(context).textTheme;

--- a/lib/screens/search.dart
+++ b/lib/screens/search.dart
@@ -29,7 +29,12 @@ class Search extends HookWidget {
         initialQuery: query,
       );
       if (newQuery != null && context.mounted) {
-        context.push("/search", extra: newQuery);
+        context.pushNamed(
+          "search",
+          queryParameters: {
+            "q": newQuery.keywords,
+          },
+        );
       }
     }
 


### PR DESCRIPTION
今まで未実装だった`/search`に対するディープリンクを実装しました。

変更点：
- `GoRoute`の`builder`で`GoRouteState.extra`ではなく`GoRouteState.queryParameters`を使ってルートを作成するように変更
- 今まで`context.push`していた箇所を`context.pushNamed`で書き換え
